### PR TITLE
Firmware Fixes

### DIFF
--- a/Analysis/ScanLibraries/source/XiaListModeDataMask.cpp
+++ b/Analysis/ScanLibraries/source/XiaListModeDataMask.cpp
@@ -14,7 +14,6 @@ using namespace DataProcessing;
 FIRMWARE XiaListModeDataMask::ConvertStringToFirmware(const std::string &type) {
     FIRMWARE firmware = UNKNOWN;
     unsigned int firmwareNumber = 0;
-    stringstream msg;
 
     //First convert the string into a number
     if (type.find("R") == 0 || type.find("r") == 0) {
@@ -37,10 +36,13 @@ FIRMWARE XiaListModeDataMask::ConvertStringToFirmware(const std::string &type) {
         firmware = R30980;
     else if (firmwareNumber >= 30981 && firmwareNumber < 34688)
         firmware = R30981;
-    else if (firmwareNumber >= 34688)
+    else if (firmwareNumber >= 34688) {
         firmware = R34688;
-    else
-        throw invalid_argument("XiaListModeDataMask::CovnertStringToFirmware : Unrecognized firmware option - " + type);
+        if(firmwareNumber > 34688)
+            cout << "XiaListModeDataMask::ConvertStringToFirmware :  You requested a firmware number that's higher "
+                    "than the last known number. You should confirm that headers has the same format !!" << endl;
+    } else
+        throw invalid_argument("XiaListModeDataMask::ConvertStringToFirmware : Unrecognized firmware option - " + type);
     return firmware;
 }
 

--- a/Analysis/ScanLibraries/tests/unittest-XiaListModeDataMask.cpp
+++ b/Analysis/ScanLibraries/tests/unittest-XiaListModeDataMask.cpp
@@ -71,13 +71,13 @@ CHECK_EQUAL(R30474, ConvertStringToFirmware("30670")
 CHECK_EQUAL(R30981, ConvertStringToFirmware("32000")
 );
 
+
+CHECK_EQUAL(R34688, ConvertStringToFirmware("45000"));
+
 //Two cases for absolute failure of the method is when we have a firmware
 // version that is higher than the highest known one, and a version
 // smaller than the smallest known version.
-CHECK_THROW(ConvertStringToFirmware("45000"), invalid_argument
-);
-CHECK_THROW(ConvertStringToFirmware("12"), invalid_argument
-);
+CHECK_THROW(ConvertStringToFirmware("12"), invalid_argument);
 }
 
 TEST_FIXTURE(XiaListModeDataMask, TestXiaListModeDataMask


### PR DESCRIPTION
Resolves

- #41 - Adds warning via `cout` if the number is larger than the largest enum.