### PR TITLE
Changed CTerminal to only to remove prompt on enter.

### DIFF
--- a/Core/include/CTerminal.h
+++ b/Core/include/CTerminal.h
@@ -188,6 +188,9 @@ private:
     void
     split_commands(const std::string &input_, std::deque<std::string> &cmds);
 
+    /// Print the command prompt to the screen.
+    void PrintPrompt();
+
 public:
     Terminal();
 

--- a/Core/source/CTerminal.cpp
+++ b/Core/source/CTerminal.cpp
@@ -297,12 +297,12 @@ void Terminal::update_cursor_() {
 }
 
 void Terminal::clear_() {
-    for (int start = cmd.length() + offset; start >= offset; start--) {
+    for (int start = cmd.length() + offset; start >= 0; start--) {
         wmove(input_window, 0, start);
         wdelch(input_window);
     }
     cmd.clear();
-    cursX = offset;
+    cursX = 0;
     update_cursor_();
     refresh_();
 }
@@ -657,12 +657,15 @@ void Terminal::SetPrompt(const char *input_) {
             }
         }
     }
-    print(input_window, prompt.c_str());
-
     offset += prompt.length() - lastPos;
+
+    PrintPrompt();
+}
+
+void Terminal::PrintPrompt() {
+    print(input_window, prompt.c_str());
     cursX = offset;
     update_cursor_();
-
     refresh_();
 }
 
@@ -839,8 +842,10 @@ void Terminal::PrintCommand(const std::string &cmd_) {
     tabCount = 0;
 }
 
-std::string
-Terminal::GetCommand(std::string &args, const int &prev_cmd_return_/*=0*/) {
+std::string Terminal::GetCommand(std::string &args, const int &prev_cmd_return_/*=0*/) {
+    if (cursX == 0) {
+        PrintPrompt();
+    }
     std::string output = "";
 
     sclock::time_point commandRequestTime = sclock::now();
@@ -964,6 +969,7 @@ Terminal::GetCommand(std::string &args, const int &prev_cmd_return_/*=0*/) {
                 std::string temp_cmd = commands.GetPrev();
                 if (temp_cmd != "NULL") {
                     clear_();
+                    PrintPrompt();
                     cmd.assign(temp_cmd);
                     in_print_(cmd.c_str());
                 }
@@ -971,6 +977,7 @@ Terminal::GetCommand(std::string &args, const int &prev_cmd_return_/*=0*/) {
                 std::string temp_cmd = commands.GetNext();
                 if (temp_cmd != "NULL") {
                     clear_();
+                    PrintPrompt();
                     cmd.assign(temp_cmd);
                     in_print_(cmd.c_str());
                 }
@@ -1137,7 +1144,7 @@ void Terminal::Close() {
 
 /**Split a string on the delimiter character populating the vector args with 
  * any substrings formed. Returns the number of substrings found.
- *	
+ *
  * \param[in] str The string to be parsed.
  * \param[out] args The vector to populate with substrings.
  * \param[in] delimiter The character to split the string on.
@@ -1176,7 +1183,7 @@ unsigned int split_str(std::string str, std::vector<std::string> &args,
 }
 
 /**Split strings into multiple commands separated by ';'.
- *	
+ *
  * \param[in] input_ The string to be parsed.
  * \param[out] cmds The vector to populate with sub-commands.
  */

--- a/Core/tests/CTerminalTest.cpp
+++ b/Core/tests/CTerminalTest.cpp
@@ -10,7 +10,7 @@
 int main(int argc, char *argv[]) {
     bool debug = false;
     //Vector of possible commands.
-    std::vector<std::string> commandChoices = {"help", "quit", "debug", "tab"};
+    std::vector<std::string> commandChoices = {"help", "quit", "debug", "sleep", "tab"};
     //Map of vector possible arguments for a given command.
     std::map<std::string, std::vector<std::string> > argumentChoices;
     argumentChoices["tab"] = std::vector<std::string> {"arg1", "arg2"};

--- a/Core/tests/CTerminalTest.cpp
+++ b/Core/tests/CTerminalTest.cpp
@@ -31,6 +31,8 @@ int main(int argc, char *argv[]) {
         if (debug)
             std::cout << "TEST: cmd='" << cmd << "' arg='" << arg << "'\n";
 
+        if (cmd == "") continue;
+
         if (cmd.find("\t") != std::string::npos) {
             term.TabComplete(cmd, commandChoices);
             continue;

--- a/Core/tests/CTerminalTest.cpp
+++ b/Core/tests/CTerminalTest.cpp
@@ -3,6 +3,8 @@
 #include <map>
 #include <string>
 #include <iostream>
+#include <unistd.h>
+
 #include "CTerminal.h"
 
 int main(int argc, char *argv[]) {
@@ -53,6 +55,19 @@ int main(int argc, char *argv[]) {
         } else if (cmd == "tab") {
             std::cout << "This command tests the argument tab completion.\n";
             std::cout << "\tTab Completion arguments: '" << arg << "'\n";
+        } else if (cmd == "sleep") {
+            int sleepTime = 1;
+            if (!arg.empty()) {
+                try {
+                    sleepTime = std::stoi(arg);
+                } catch (...) {
+                    std::cout << "ERROR: Unable to convert '" << arg << "' to an integer number of seconds!\n";
+                    continue;
+                }
+            }
+            std::cout << "Sleeping for " << sleepTime << " s.\n";
+            term.flush();
+            sleep(sleepTime);
         } else {
             std::cout << "Unknown command: '" << cmd << "'\n";
         }


### PR DESCRIPTION
This enhancement clears the prompt text while the command is run to indicate that the system is busy. This is designed for long running commands, as previously users would keep typing commands even though the command thread was busy executing tasks. In addition, this allows enter to be pressed and a fresh prompt to be displayed indicating that the system is responsive. This behavior more closely matches that of bash and others.

When a command is entered the prompt is cleared until GetCommand is
called again. The KEY_UP and KEY_DOWN commands call clear_ and required
printing of the prompt after the clear_ as well.