### PR TITLE
Resolved issue #53 (incorrrect exit message).

### DIFF
--- a/Acquisition/Setup/Traces/share/traces/tra
+++ b/Acquisition/Setup/Traces/share/traces/tra
@@ -19,5 +19,5 @@ system "get_traces ".MOD." ".CH
 
 if (CH<0) n=16; call dir.'plotTraces_mod'; else n=1; call dir.'plotTraces_ch'
 
-print "Press any key to exit..."
+print "Press Enter to exit..."
 pause -1


### PR DESCRIPTION
The viewBaseline script ends with a message to press any key to exit. Changed
message to state that Enter must be pressed as this was the only key to change
the status. This resolves #53.