### PR TITLE
Resolves #87 - Flags for Analysis Utilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
             - gsl-bin
             - libgsl0-dev
             - libncurses5-dev
+            - libroot*
       env:
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
     - os: linux
@@ -38,6 +39,7 @@ matrix:
             - gsl-bin
             - libgsl0-dev
             - libncurses5-dev
+            - libroot*
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
@@ -52,6 +54,6 @@ before_install:
 
 script:
   - mkdir paass-build && mkdir install
-  - cd paass-build && cmake ../ -DPAASS_BUILD_TESTS=ON -DPAASS_BUILD_UTKSCAN=ON -DPAASS_USE_ROOT=OFF && make install
+  - cd paass-build && cmake ../ -DPAASS_BUILD_TESTS=ON -DPAASS_BUILD_UTKSCAN=ON -DPAASS_USE_ROOT=ON -DPAASS_BUILD_SCAN_UTILITIES=OFF && make install
   - cd ../install/bin/unittests/
   - (for test in *; do echo $test; ./$test; if [ $? != 0 ]; then false; exit; fi; done)

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,6 @@ before_install:
 
 script:
   - mkdir paass-build && mkdir install
-  - cd paass-build && cmake ../ -DPAASS_BUILD_TESTS=ON -DPAASS_BUILD_UTKSCAN=ON -DPAASS_USE_ROOT=ON -DPAASS_BUILD_SCAN_UTILITIES=OFF && make install
+  - cd paass-build && cmake ../ -DPAASS_BUILD_TESTS=ON -DPAASS_BUILD_UTKSCAN=ON -DPAASS_BUILD_ROOT_SCANNER=OFF && make install
   - cd ../install/bin/unittests/
   - (for test in *; do echo $test; ./$test; if [ $? != 0 ]; then false; exit; fi; done)

--- a/Analysis/CMakeLists.txt
+++ b/Analysis/CMakeLists.txt
@@ -1,4 +1,5 @@
 #@authors K. Smith, S. V. Paulauskas, C. R. Thornsberry
+option(PAASS_BUILD_UTKSCAN "Build utkscan" OFF)
 option(PAASS_USE_HRIBF "Use HRIBF library for scan base." OFF)
 
 #Check if GSL is installed
@@ -29,9 +30,7 @@ add_subdirectory(ScanLibraries)
 add_subdirectory(Resources)
 
 #Build utilities.
-if(PAASS_BUILD_SCAN_UTILITIES)
-    add_subdirectory(Utilities)
-endif(PAASS_BUILD_SCAN_UTILITIES)
+add_subdirectory(Utilities)
 
 if (PAASS_BUILD_UTKSCAN)
     add_subdirectory(Utkscan)

--- a/Analysis/Utilities/CMakeLists.txt
+++ b/Analysis/Utilities/CMakeLists.txt
@@ -1,11 +1,39 @@
 # @author S. V. Paulauskas
+option(PAASS_BUILD_EVENT_READER "Program that outputs event information to the terminal" ON)
+option(PAASS_BUILD_HEAD_READER "Program that outputs the header information from the file" ON)
+option(PAASS_BUILD_HEX_READER "Program that outputs data as hex values" ON)
+option(PAASS_BUILD_ROOT_SCANNER "Program used for live scanning of files into ROOT hists" ON)
+option(PAASS_BUILD_SCOPE "Program used to view traces in data stream" ON)
+option(PAASS_BUILD_SKELETON "Program that can be used to build custom Analysis" ON)
+option(PAASS_BUILD_TRACE_FILTERER "Program that performs filtering on traces" ON)
+
+if(PAASS_BUILD_EVENT_READER)
+    add_subdirectory(EventReader)
+endif(PAASS_BUILD_EVENT_READER)
+
+if(PAASS_BUILD_HEAD_READER)
+    add_subdirectory(HeadReader)
+endif(PAASS_BUILD_HEAD_READER)
+
+if(PAASS_BUILD_HEX_READER)
+    add_subdirectory(HexReader)
+endif(PAASS_BUILD_HEX_READER)
+
+if(PAASS_BUILD_SKELETON)
+    add_subdirectory(Skeleton)
+endif(PAASS_BUILD_SKELETON)
+
+if(PAASS_BUILD_TRACE_FILTERER)
+    add_subdirectory(TraceFilterer)
+endif(PAASS_BUILD_TRACE_FILTERER)
+
 if (PAASS_USE_ROOT)
-    add_subdirectory(Scope)
-    add_subdirectory(RootScanner)
+    if(PAASS_BUILD_ROOT_SCANNER)
+        add_subdirectory(RootScanner)
+    endif(PAASS_BUILD_ROOT_SCANNER)
+
+    if(PAASS_BUILD_SCOPE)
+        add_subdirectory(Scope)
+    endif(PAASS_BUILD_SCOPE)
 endif (PAASS_USE_ROOT)
 
-add_subdirectory(EventReader)
-add_subdirectory(HeadReader)
-add_subdirectory(HexReader)
-add_subdirectory(Skeleton)
-add_subdirectory(TraceFilterer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,10 @@ include(CMakeDependentOption)
 
 #Install options
 option(PAASS_BUILD_ACQ "Build and install Acquisition software" ON)
-option(PAASS_BUILD_SCAN_UTILITIES "Build and install the Analysis Utilities" ON)
+option(PAASS_BUILD_ANALYSIS "Build analysis related programs" ON)
 option(PAASS_BUILD_SETUP "Include the older setup programs in installation" OFF)
 option(PAASS_BUILD_SHARED_LIBS "Install only scan libraries" ON)
 option(PAASS_BUILD_TESTS "Builds programs designed to test the package. Including UnitTest++ test." OFF)
-option(PAASS_BUILD_UTKSCAN "Build utkscan" OFF)
 option(PAASS_USE_DAMM "Use DAMM for MCA" ON)
 option(PAASS_USE_ROOT "Use ROOT" ON)
 
@@ -143,7 +142,9 @@ else ()
 endif (PAASS_BUILD_ACQ)
 
 #Build any of the analysis related things that we need to build.
-add_subdirectory(Analysis)
+if(PAASS_BUILD_ANALYSIS)
+    add_subdirectory(Analysis)
+endif(PAASS_BUILD_ANALYSIS)
 
 #Build/install the miscellaneous stuff
 add_subdirectory(Share)


### PR DESCRIPTION
We needed these options to allow finer control of the Analysis utilities
build. We build all Analysis utilities by default to maintain
consistent behavior. I replaced PAASS_BUILD_SCAN_UTILITIES with
PAASS_BUILD_ANALYSIS. This creates consistent behavior with the
PAASS_BUILD_ACQ option.